### PR TITLE
Updating & Improving Subtitle Representation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-hebrew-subtitles",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Stremio Addon for Hebrew subtitles from all the top notch websites in one convenient location.",
   "main": "index.js",
   "scripts": {
@@ -23,11 +23,10 @@
     "adm-zip": "^0.5.12",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "fastest-levenshtein": "^1.0.16",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.45",
     "pg": "^8.11.5",
-    "superagent": "^9.0.2",
+    "string-similarity": "^4.0.4",
     "undici": "^6.18.0",
     "winston": "^3.13.0"
   },

--- a/src/services/osService.js
+++ b/src/services/osService.js
@@ -24,16 +24,18 @@ const fetchSubtitlesFromOS = async (imdbID, season, episode) => {
 
 const mapSubtitlesToStremio = (subtitles) => {
     return subtitles.map((s) => ({
-        url: `${baseConfig.BASE_URL}/subtitles/OS/${s.imdbID}/${s.season}/${s.episode}/${s.id}.srt`,
         id: s.name,
+        provider: "OpenSubtitles",
+        score: 0,
         lang: "heb",
+        url: `${baseConfig.BASE_URL}/subtitles/OS/${s.imdbID}/${s.season}/${s.episode}/${s.id}.srt`,
     }));
 };
 
 const extractSubtitleFromOS = async (subtitleID) => {
     const url = osApi.DOWNLOAD_URL;
 
-    const linkResponse = await safePost(url, { file_id: subtitleID });
+    const linkResponse = await safePost(url, { file_id: subtitleID }, osConfig.getApiKeysLength);
     const responseBody = await linkResponse.body.json();
     const srtLink = responseBody.link;
 
@@ -43,7 +45,7 @@ const extractSubtitleFromOS = async (subtitleID) => {
     return srtContent;
 };
 
-const safePost = async (url, body, tries = 2) => {
+const safePost = async (url, body, tries) => {
     let response;
 
     while (tries) {

--- a/src/services/stremioService.js
+++ b/src/services/stremioService.js
@@ -1,8 +1,8 @@
-import levenshtein from "fastest-levenshtein";
+import lodash from "lodash";
+import stringSimilarity from "string-similarity";
 
 import osController from "../controllers/osController.js";
 import wizdomController from "../controllers/wizdomController.js";
-import lodash from "lodash";
 
 
 const getSubtitleSrt = async (provider, subtitleID) => {
@@ -22,13 +22,16 @@ const getSubtitlesList = async (userConfig, imdbID, season, episode) => {
 };
 
 const sortSubtitlesByFilename = (subtitles, filename) => {
-  return subtitles.sort((a, b) => {
-    const similarityA = levenshtein.distance(a.id, filename);
-    const similarityB = levenshtein.distance(b.id, filename);
+  return subtitles.map(s => {
+    const similarity = stringSimilarity.compareTwoStrings(s.id, filename);
+    const percentage = (similarity * 100).toFixed(2);
 
-    return similarityA - similarityB;
-  });
-}
+    s.id = `${percentage}% [${s.provider}] ${s.id}`;
+    s.score = parseFloat(percentage);
+    return s;
+
+  }).sort((a, b) => b.score - a.score);
+};
 
 const mergeSubtitles = (subtitles, providerSubtitles) => {
   const mergedSubtitles = lodash.unionBy(subtitles, providerSubtitles, 'id');

--- a/src/services/wizdomService.js
+++ b/src/services/wizdomService.js
@@ -23,9 +23,11 @@ const fetchSubtitlesFromWizdom = async (imdbID, season, episode) => {
 
 const mapSubtitlesToStremio = (subtitles) => {
     return subtitles.map((s) => ({
-        url: `${baseConfig.BASE_URL}/subtitles/Wizdom/${s.imdbID}/${s.season}/${s.episode}/${s.id}.srt`,
         id: s.name,
+        provider: "Wizdom",
+        score: 0,
         lang: "heb",
+        url: `${baseConfig.BASE_URL}/subtitles/Wizdom/${s.imdbID}/${s.season}/${s.episode}/${s.id}.srt`,
     }));
 };
 


### PR DESCRIPTION
As @TwilightMercy suggest in [Issue #3](https://github.com/Nitzantomer1998/UniversalHebrewSubtitles/issues/3#issue-2304382162)

> I think combining 1+2 will be the best. I think that including filename in the Sub ID will be too long and confusing, and the percentage match is very important for people to see (from long time Israel community experience)
> 
> So something like in the picture I sent from DarkSubs addon will be the most helpful:
> 
> 72% [Wizdom] Godzilla x Kong The New Empire 2024 1080p AMZN WEB-DL DDP5 1 1 H 264-FLUX

This suggestion proved to be a good and better subtitle representation. As a result, it has been integrated into the application.